### PR TITLE
Convert LiteAnalyzer's detection's np.float32 values to float values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [
 
 [project]
 name = "birdnetlib"
-version = "0.0.19"
+version = "0.0.20"
 authors = [
   { name="Joe Weiss", email="joe.weiss@gmail.com" },
 ]

--- a/src/birdnetlib/main.py
+++ b/src/birdnetlib/main.py
@@ -122,7 +122,10 @@ class Detection:
 
     @property
     def confidence(self):
-        return self.data[0][1]
+        confidence = self.data[0][1]
+        if type(confidence) is np.float32:
+            return confidence.item()
+        return confidence
 
     @property
     def scientific_name(self):

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -69,6 +69,9 @@ def test_without_species_list():
         len(analyzer.custom_species_list) == 154
     )  # Check that this matches the number printed by the cli version.
 
+    # Check that detection confidence is float.
+    assert type(recording.detections[0]["confidence"]) is float
+
 
 def test_with_species_list():
 

--- a/tests/test_analyzer_lite.py
+++ b/tests/test_analyzer_lite.py
@@ -70,9 +70,11 @@ def test_basic():
     assert recording.detections[0]["common_name"] == "House Wren"
     assert pytest.approx(recording.detections[0]["confidence"], 0.01) == 0.27517712
 
+    # Check that detection confidence is float.
+    assert type(recording.detections[0]["confidence"]) is float
+
     assert commandline_results[0]["common_name"] == "House Wren"
     assert pytest.approx(commandline_results[0]["confidence"], 0.01) == 0.27517712
-
 
 def test_with_custom_list():
 


### PR DESCRIPTION
This change ensures that LiteAnalyzer's detection format matches the Analyzer's format.

Fixes #37