### PR TITLE
Add ability to return the duration of evaluated audio source

### DIFF
--- a/dev/docker-m1-requirements.txt
+++ b/dev/docker-m1-requirements.txt
@@ -9,7 +9,7 @@ charset-normalizer==2.1.0
 click==8.1.3
 decorator==5.1.1
 Flask==2.1.3
-flatbuffers==2.0
+flatbuffers==2.0.7
 gast==0.5.3
 google-auth==2.9.1
 google-auth-oauthlib==0.4.6

--- a/src/birdnetlib/main.py
+++ b/src/birdnetlib/main.py
@@ -31,6 +31,7 @@ class Recording:
         self.overlap = 0.0
         self.minimum_confidence = max(0.01, min(min_conf, 0.99))
         self.sample_secs = 3.0
+        self.duration = None
 
     def analyze(self):
         # Compute date to week_48 format as required by current BirdNET analyzers.
@@ -79,6 +80,7 @@ class Recording:
             sig, rate = librosa.load(
                 self.path, sr=sample_rate, mono=True, res_type="kaiser_fast"
             )
+            self.duration = librosa.get_duration(y=sig, sr=sample_rate)
         except audioread.exceptions.NoBackendError as e:
             print(e)
             raise AudioFormatError("Audio format could not be opened.")

--- a/src/birdnetlib/main.py
+++ b/src/birdnetlib/main.py
@@ -84,6 +84,12 @@ class Recording:
         except audioread.exceptions.NoBackendError as e:
             print(e)
             raise AudioFormatError("Audio format could not be opened.")
+        except FileNotFoundError as e:
+            print(e)
+            raise e
+        except BaseException as e:
+            print(e)
+            raise AudioFormatError("Generic audio read error occurred from librosa.")
 
         # Split audio into 3-second chunks
 

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -125,6 +125,9 @@ def test_with_species_list():
         min_conf=min_conf,
     )
     recording.analyze()
+
+    assert recording.duration == 120
+
     pprint(recording.detections)
 
     assert (

--- a/tests/test_analyzer_lite.py
+++ b/tests/test_analyzer_lite.py
@@ -64,6 +64,8 @@ def test_basic():
 
     # pprint(recording.detections)
 
+    assert round(recording.duration) == 137
+
     assert len(recording.detections) == 6
     assert len(commandline_results) == 6
 


### PR DESCRIPTION
```
from birdnetlib import Recording
from birdnetlib.analyzer import Analyzer
from datetime import datetime

# Load and initialize the BirdNET-Analyzer models.
analyzer = Analyzer()

recording = Recording(
    analyzer,
    "sample.mp3",
    lat=35.4244,
    lon=-120.7463,
    date=datetime(year=2022, month=5, day=10), # use date or week_48
    min_conf=0.25,
)
recording.analyze()
print(recording.detections)
print(recording.duration) # Returns duration of sample.mp3 in seconds (as float).
```



