### PR TITLE
Add ability to extract audio for detections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 examples/*.mp3
 examples/*.wav
 examples/*/*.wav
+
+examples/flac
+examples/*.flac

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ print(species_list)
 - [Watch a directory for new files, then analyze with multiple analyzer models as files are saved](https://github.com/joeweiss/birdnetlib/blob/main/examples/watch_directory_multi_analyzer.py)
 - [Watch a directory for new files, and apply datetimes by parsing file names (eg _2022-08-15-birdnet-21:05:52.wav_) prior to analyzing](https://github.com/joeweiss/birdnetlib/blob/main/examples/watch_directory_date_filenames.py) This example can also be used to modify lat/lon, min_conf, etc., based on file name prior to analyzing.
 - [Limit detections to certain species by passing a predefined species list to the analyzer](https://github.com/joeweiss/birdnetlib/blob/main/examples/predefined_species_list.py) Useful when searching for a particular set of bird detections.
+- [Extract detections as audio file samples](https://github.com/joeweiss/birdnetlib/blob/main/examples/analyze_and_extract.py) Supports extractions as .flac, .wav and .mp3. Can be filtered to only extract files above a separate minimum confidence value.
 
 ## About BirdNET-Lite and BirdNET-Analyzer
 
@@ -152,7 +153,7 @@ For more information on BirdNET analyzers, please see the project repositories b
 
 ## About `birdnetlib`
 
-`birdnetlib` is maintained by Joe Weiss.
+`birdnetlib` is maintained by Joe Weiss. Contributions are welcome.
 
 ### Project Goals
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/birdnetlib.svg)](https://pypi.org/project/birdnetlib/)
 [![Test](https://github.com/joeweiss/birdnetlib/actions/workflows/test.yml/badge.svg)](https://github.com/joeweiss/birdnetlib/actions/workflows/test.yml)
 
-A python api for BirdNET-Lite and BirdNET-Analyzer
+A python api for BirdNET-Analyzer and BirdNET-Lite
 
 ## Installation
 
@@ -15,7 +15,31 @@ pip install birdnetlib
 
 ## Documentation
 
-`birdnetlib` provides a common interface for BirdNET-Lite and BirdNET-Analyzer.
+`birdnetlib` provides a common interface for BirdNET-Analyzer and BirdNET-Lite.
+
+### Using BirdNET-Analyzer
+
+To use the newer BirdNET-Analyzer model, use the `Analyzer` class.
+
+```
+from birdnetlib import Recording
+from birdnetlib.analyzer import Analyzer
+from datetime import datetime
+
+# Load and initialize the BirdNET-Analyzer models.
+analyzer = Analyzer()
+
+recording = Recording(
+    analyzer,
+    "sample.mp3",
+    lat=35.4244,
+    lon=-120.7463,
+    date=datetime(year=2022, month=5, day=10), # use date or week_48
+    min_conf=0.25,
+)
+recording.analyze()
+print(recording.detections)
+```
 
 ### Using BirdNET-Lite
 
@@ -54,30 +78,6 @@ print(recording.detections) # Returns list of detections.
   'end_time': 15.0,
   'scientific_name': 'Haemorhous mexicanus',
   'start_time': 12.0}]
-```
-
-### Using BirdNET-Analyzer
-
-To use the newer BirdNET-Analyzer model, use the `Analyzer` class.
-
-```
-from birdnetlib import Recording
-from birdnetlib.analyzer import Analyzer
-from datetime import datetime
-
-# Load and initialize the BirdNET-Analyzer models.
-analyzer = Analyzer()
-
-recording = Recording(
-    analyzer,
-    "sample.mp3",
-    lat=35.4244,
-    lon=-120.7463,
-    date=datetime(year=2022, month=5, day=10), # use date or week_48
-    min_conf=0.25,
-)
-recording.analyze()
-print(recording.detections)
 ```
 
 ### Utility classes

--- a/examples/analyze_and_extract.py
+++ b/examples/analyze_and_extract.py
@@ -1,0 +1,69 @@
+from birdnetlib import Recording
+from birdnetlib.analyzer import Analyzer
+from birdnetlib.analyzer import Analyzer
+from datetime import datetime
+from pprint import pprint
+
+# Load and initialize the BirdNET-Analyzer models.
+analyzer = Analyzer()
+
+recording = Recording(
+    analyzer,
+    "2022-08-15-birdnet-21:05:54.wav",
+    lat=35.4244,
+    lon=-120.7463,
+    date=datetime(year=2022, month=5, day=10),  # use date or week_48
+    min_conf=0.25,
+)
+recording.analyze()
+export_dir = "extractions"  # Directory should already exist.
+
+# Extract to default audio files (.flac)
+recording.extract_detection_as_audio(directory=export_dir)
+
+pprint(recording.detections)
+
+"""
+[{'common_name': 'House Finch',
+  'confidence': 0.5066996216773987,
+  'end_time': 12.0,
+  'extraction_path': 'extractions/2022-08-15-birdnet-21:05:54_7s-14s.flac',
+  'scientific_name': 'Haemorhous mexicanus',
+  'start_time': 9.0},
+ {'common_name': 'Dark-eyed Junco',
+  'confidence': 0.3555494546890259,
+  'end_time': 36.0,
+  'extraction_path': 'extractions/2022-08-15-birdnet-21:05:54_31s-38s.flac',
+  'scientific_name': 'Junco hyemalis',
+  'start_time': 33.0}
+ ]
+ """
+
+
+recording = Recording(
+    analyzer,
+    "2022-08-15-birdnet-21:05:54.wav",
+    lat=35.4244,
+    lon=-120.7463,
+    date=datetime(year=2022, month=5, day=10),  # use date or week_48
+    min_conf=0.25,
+)
+recording.analyze()
+export_dir = "extractions"  # Directory should already exist.
+
+# Extract to .mp3 audio files, only if confidence is > 0.5 with no seconds of audio padding.
+recording.extract_detection_as_audio(
+    directory=export_dir, format="mp3", bitrate="192k", min_conf=0.5, padding_secs=0
+)
+
+pprint(recording.detections)
+
+"""
+[{'common_name': 'House Finch',
+  'confidence': 0.5066996216773987,
+  'end_time': 12.0,
+  'extraction_path': 'extractions/2022-08-15-birdnet-21:05:54_7s-14s.mp3',
+  'scientific_name': 'Haemorhous mexicanus',
+  'start_time': 9.0}
+ ]
+ """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "watchdog==2.1.9"
+    "watchdog==2.1.9",
+    "pydub==0.25.1"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [
 
 [project]
 name = "birdnetlib"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
   { name="Joe Weiss", email="joe.weiss@gmail.com" },
 ]

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,0 +1,118 @@
+from birdnetlib import Recording
+from birdnetlib.analyzer import Analyzer
+
+from pprint import pprint
+import os
+import tempfile
+import pydub
+import pytest
+
+
+def test_extraction():
+
+    lon = -120.7463
+    lat = 35.4244
+    week_48 = 18
+    min_conf = 0.25
+    input_path = os.path.join(os.path.dirname(__file__), "test_files/soundscape.wav")
+
+    analyzer = Analyzer()
+    recording = Recording(
+        analyzer,
+        input_path,
+        lat=lat,
+        lon=lon,
+        week_48=week_48,
+        min_conf=min_conf,
+    )
+    recording.analyze()
+
+    """
+    TODO: Remove this comment after feature is defined.
+
+    # Local development tests.
+    
+    export_dir = os.path.join(os.path.dirname(__file__), "extractions")
+
+    # Export to mp3 @ 128k for all detections with min_conf of 0.8.
+    recording.extract_detection_as_audio(
+        directory=export_dir, format="mp3", bitrate="128k", min_conf=0.5
+    )
+
+    """
+
+    # flac test in temporary test directory.
+    with tempfile.TemporaryDirectory() as export_dir:
+        recording.extract_detection_as_audio(directory=export_dir)
+
+        # Check file list.
+        files = os.listdir(export_dir)
+        assert files == [
+            "soundscape_33s-36s.flac",
+            "soundscape_69s-72s.flac",
+            "soundscape_51s-54s.flac",
+            "soundscape_9s-12s.flac",
+            "soundscape_42s-45s.flac",
+            "soundscape_60s-63s.flac",
+            "soundscape_84s-87s.flac",
+            "soundscape_93s-96s.flac",
+            "soundscape_66s-69s.flac",
+        ]
+
+        # Check that file format is flac, 48000, and correct size.
+        with pytest.raises(pydub.exceptions.CouldntDecodeError):
+            audio = pydub.AudioSegment.from_mp3(f"{export_dir}/{files[0]}")
+        audio = pydub.AudioSegment.from_file(f"{export_dir}/{files[0]}")
+        assert audio.frame_rate == 48000
+        assert audio.duration_seconds == 3.0
+
+    # wav test in temporary test directory.
+    with tempfile.TemporaryDirectory() as export_dir:
+        recording.extract_detection_as_audio(directory=export_dir, format="wav")
+
+        # Check file list.
+        files = os.listdir(export_dir)
+        assert files == [
+            "soundscape_9s-12s.wav",
+            "soundscape_51s-54s.wav",
+            "soundscape_42s-45s.wav",
+            "soundscape_93s-96s.wav",
+            "soundscape_84s-87s.wav",
+            "soundscape_60s-63s.wav",
+            "soundscape_66s-69s.wav",
+            "soundscape_33s-36s.wav",
+            "soundscape_69s-72s.wav",
+        ]
+
+        # Check that file format is wav, 48000, and correct size.
+        audio = pydub.AudioSegment.from_wav(f"{export_dir}/{files[0]}")
+        assert audio.frame_rate == 48000
+        assert audio.duration_seconds == 3.0
+
+    # mp3 test in temporary test directory (with custom min_conf extraction)
+    with tempfile.TemporaryDirectory() as export_dir:
+
+        recording.extract_detection_as_audio(
+            directory=export_dir,
+            format="mp3",
+            bitrate="128k",
+            min_conf=0.4,
+            padding_secs=2,
+        )
+
+        # Check file list.
+        files = os.listdir(export_dir)
+        print("yo")
+        pprint(files)
+
+        assert files == [
+            "soundscape_82s-89s.mp3",
+            "soundscape_40s-47s.mp3",
+            "soundscape_7s-14s.mp3",
+            "soundscape_64s-71s.mp3",
+        ]
+
+        # Check that file format is mp3, 48000, and 128k bitrate.
+        audio = pydub.AudioSegment.from_mp3(f"{export_dir}/{files[0]}")
+        assert audio.frame_rate == 48000
+        assert audio.duration_seconds == 7.0

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -47,17 +47,20 @@ def test_extraction():
 
         # Check file list.
         files = os.listdir(export_dir)
-        assert files == [
+        files.sort()
+        expected_files = [
+            "soundscape_9s-12s.flac",
             "soundscape_33s-36s.flac",
             "soundscape_69s-72s.flac",
             "soundscape_51s-54s.flac",
-            "soundscape_9s-12s.flac",
             "soundscape_42s-45s.flac",
             "soundscape_60s-63s.flac",
             "soundscape_84s-87s.flac",
             "soundscape_93s-96s.flac",
             "soundscape_66s-69s.flac",
         ]
+        expected_files.sort()
+        assert files == expected_files
 
         # Check that file format is flac, 48000, and correct size.
         with pytest.raises(pydub.exceptions.CouldntDecodeError):
@@ -72,7 +75,9 @@ def test_extraction():
 
         # Check file list.
         files = os.listdir(export_dir)
-        assert files == [
+        files.sort()
+
+        expected_files = [
             "soundscape_9s-12s.wav",
             "soundscape_51s-54s.wav",
             "soundscape_42s-45s.wav",
@@ -83,6 +88,8 @@ def test_extraction():
             "soundscape_33s-36s.wav",
             "soundscape_69s-72s.wav",
         ]
+        expected_files.sort()
+        assert files == expected_files
 
         # Check that file format is wav, 48000, and correct size.
         audio = pydub.AudioSegment.from_wav(f"{export_dir}/{files[0]}")
@@ -102,15 +109,16 @@ def test_extraction():
 
         # Check file list.
         files = os.listdir(export_dir)
-        print("yo")
-        pprint(files)
-
-        assert files == [
+        files.sort()
+        expected_files = [
+            "soundscape_7s-14s.mp3",
             "soundscape_82s-89s.mp3",
             "soundscape_40s-47s.mp3",
-            "soundscape_7s-14s.mp3",
             "soundscape_64s-71s.mp3",
         ]
+        expected_files.sort()
+
+        assert files == expected_files
 
         # Check that file format is mp3, 48000, and 128k bitrate.
         audio = pydub.AudioSegment.from_mp3(f"{export_dir}/{files[0]}")


### PR DESCRIPTION
Add the ability to extract audio files for each detection. 
Includes the ability to define separate minimum confidence for extraction routine.
Exports to .wav, .flac and .mp3.

```

# Load and initialize the BirdNET-Analyzer models.
analyzer = Analyzer()

recording = Recording(
    analyzer,
    "2022-08-15-birdnet-21:05:54.wav",
    lat=35.4244,
    lon=-120.7463,
    date=datetime(year=2022, month=5, day=10),  # use date or week_48
    min_conf=0.25,
)
recording.analyze()
export_dir = "extractions"  # Directory should already exist.

# Extract to default audio files (.flac)
recording.extract_detection_as_audio(directory=export_dir)

pprint(recording.detections)

"""
[{'common_name': 'House Finch',
  'confidence': 0.5066996216773987,
  'end_time': 12.0,
  'extraction_path': 'extractions/2022-08-15-birdnet-21:05:54_9s-12s.flac',
  'scientific_name': 'Haemorhous mexicanus',
  'start_time': 9.0},
 {'common_name': 'Dark-eyed Junco',
  'confidence': 0.3555494546890259,
  'end_time': 36.0,
  'extraction_path': 'extractions/2022-08-15-birdnet-21:05:54_33s-36s.flac',
  'scientific_name': 'Junco hyemalis',
  'start_time': 33.0}
 ]
 """

```