### PR TITLE
Add ability to extract spectrogram from detections

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ print(species_list)
 - [Watch a directory for new files, then analyze with multiple analyzer models as files are saved](https://github.com/joeweiss/birdnetlib/blob/main/examples/watch_directory_multi_analyzer.py)
 - [Watch a directory for new files, and apply datetimes by parsing file names (eg _2022-08-15-birdnet-21:05:52.wav_) prior to analyzing](https://github.com/joeweiss/birdnetlib/blob/main/examples/watch_directory_date_filenames.py) This example can also be used to modify lat/lon, min_conf, etc., based on file name prior to analyzing.
 - [Limit detections to certain species by passing a predefined species list to the analyzer](https://github.com/joeweiss/birdnetlib/blob/main/examples/predefined_species_list.py) Useful when searching for a particular set of bird detections.
-- [Extract detections as audio file samples](https://github.com/joeweiss/birdnetlib/blob/main/examples/analyze_and_extract.py) Supports extractions as .flac, .wav and .mp3. Can be filtered to only extract files above a separate minimum confidence value.
+- [Extract detections as audio file samples and/or spectrograms](https://github.com/joeweiss/birdnetlib/blob/main/examples/analyze_and_extract.py) Supports audio extractions as .flac, .wav and .mp3. Spectrograms exported as .png, .jpg, or other matplotlib.pyplot supported formats. Can be filtered to only extract files above a separate minimum confidence value.
 
 ## About BirdNET-Lite and BirdNET-Analyzer
 

--- a/examples/analyze_and_extract.py
+++ b/examples/analyze_and_extract.py
@@ -21,19 +21,24 @@ export_dir = "extractions"  # Directory should already exist.
 # Extract to default audio files (.flac)
 recording.extract_detections_as_audio(directory=export_dir)
 
+# Extract to spectrograms
+recording.extract_detections_as_spectrogram(directory=export_dir)
+
 pprint(recording.detections)
 
 """
 [{'common_name': 'House Finch',
   'confidence': 0.5066996216773987,
   'end_time': 12.0,
-  'extraction_path': 'extractions/2022-08-15-birdnet-21:05:54_9s-12s.flac',
+  'extracted_audio_path': 'extractions/2022-08-15-birdnet-21:05:54_9s-12s.flac',
+  'extracted_spectrogram_path': 'extractions/2022-08-15-birdnet-21:05:54_9s-12s.jpg',
   'scientific_name': 'Haemorhous mexicanus',
   'start_time': 9.0},
  {'common_name': 'Dark-eyed Junco',
   'confidence': 0.3555494546890259,
   'end_time': 36.0,
-  'extraction_path': 'extractions/2022-08-15-birdnet-21:05:54_33s-36s.flac',
+  'extracted_audio_path': 'extractions/2022-08-15-birdnet-21:05:54_33s-36s.flac',
+  'extracted_spectrogram_path': 'extractions/2022-08-15-birdnet-21:05:54_9s-12s.jpg',
   'scientific_name': 'Junco hyemalis',
   'start_time': 33.0}
  ]
@@ -56,13 +61,14 @@ recording.extract_detections_as_audio(
     directory=export_dir, format="mp3", bitrate="192k", min_conf=0.5, padding_secs=2
 )
 
+
 pprint(recording.detections)
 
 """
 [{'common_name': 'House Finch',
   'confidence': 0.5066996216773987,
   'end_time': 12.0,
-  'extraction_path': 'extractions/2022-08-15-birdnet-21:05:54_7s-14s.mp3',
+  'extracted_audio_path': 'extractions/2022-08-15-birdnet-21:05:54_7s-14s.mp3',
   'scientific_name': 'Haemorhous mexicanus',
   'start_time': 9.0}
  ]

--- a/examples/analyze_and_extract.py
+++ b/examples/analyze_and_extract.py
@@ -19,7 +19,7 @@ recording.analyze()
 export_dir = "extractions"  # Directory should already exist.
 
 # Extract to default audio files (.flac)
-recording.extract_detection_as_audio(directory=export_dir)
+recording.extract_detections_as_audio(directory=export_dir)
 
 pprint(recording.detections)
 
@@ -52,7 +52,7 @@ recording.analyze()
 export_dir = "extractions"  # Directory should already exist.
 
 # Extract to .mp3 audio files, only if confidence is > 0.5 with 2 seconds of audio padding.
-recording.extract_detection_as_audio(
+recording.extract_detections_as_audio(
     directory=export_dir, format="mp3", bitrate="192k", min_conf=0.5, padding_secs=2
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [
 
 [project]
 name = "birdnetlib"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
   { name="Joe Weiss", email="joe.weiss@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "watchdog==2.1.9",
     "pydub==0.25.1",
-    "matplotlib==3.7.0",
+    "matplotlib==3.5.3",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
 ]
 dependencies = [
     "watchdog==2.1.9",
-    "pydub==0.25.1"
+    "pydub==0.25.1",
+    "matplotlib==3.7.0",
 ]
 
 [project.urls]

--- a/src/birdnetlib/main.py
+++ b/src/birdnetlib/main.py
@@ -38,8 +38,8 @@ class Recording:
         self.sample_secs = 3.0
         self.duration = None
         self.ndarray = None
-        self.extraction_audio_paths = {}
-        self.extraction_spectrogram_paths = {}
+        self.extracted_audio_paths = {}
+        self.extracted_spectrogram_paths = {}
 
         p = Path(self.path)
         self.filestem = p.stem
@@ -81,9 +81,14 @@ class Recording:
 
                 # Add extraction paths if available.
                 extraction_key = f"{detection['start_time']}_{detection['end_time']}"
-                file_path = self.extraction_audio_paths.get(extraction_key, None)
-                if file_path:
-                    detection["extraction_path"] = file_path
+                audio_file_path = self.extracted_audio_paths.get(extraction_key, None)
+                if audio_file_path:
+                    detection["extracted_audio_path"] = audio_file_path
+                spectrogram_file_path = self.extracted_spectrogram_paths.get(
+                    extraction_key, None
+                )
+                if spectrogram_file_path:
+                    detection["extracted_spectrogram_path"] = spectrogram_file_path
                 qualified_detections.append(detection)
 
         return qualified_detections
@@ -141,7 +146,7 @@ class Recording:
         bitrate="192k",
         min_conf=0.0,
     ):
-        self.extraction_audio_paths = {}  # Clear paths before extraction.
+        self.extracted_audio_paths = {}  # Clear paths before extraction.
         for detection in self.detections:
 
             # Skip if detection is under min_conf parameter.
@@ -185,12 +190,12 @@ class Recording:
 
             # Save path for detections list.
             extraction_key = f"{detection['start_time']}_{detection['end_time']}"
-            self.extraction_audio_paths[extraction_key] = path
+            self.extracted_audio_paths[extraction_key] = path
 
     def extract_detections_as_spectrogram(
         self, directory, padding_secs=0, min_conf=0.0, top=14000, format="jpg", dpi=144
     ):
-        self.extraction_spectrogram_paths = {}  # Clear paths before extraction.
+        self.extracted_spectrogram_paths = {}  # Clear paths before extraction.
         for detection in self.detections:
 
             # Skip if detection is under min_conf parameter.
@@ -225,7 +230,7 @@ class Recording:
             extraction_spectrogram_key = (
                 f"{detection['start_time']}_{detection['end_time']}"
             )
-            self.extraction_spectrogram_paths[extraction_spectrogram_key] = path
+            self.extracted_spectrogram_paths[extraction_spectrogram_key] = path
 
 
 class Detection:

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -224,9 +224,15 @@ def test_extraction():
         assert files == expected_files
         assert len(recording.detections) == 9
 
+        detection = recording.detections[0]
+
+        # Assert confidence (round for slight float variablity across platforms)
+        assert round(detection["confidence"], 7) == 0.5066996
+
+        del detection["confidence"]
+
         expected_detection = {
             "common_name": "House Finch",
-            "confidence": 0.5066996216773987,
             "end_time": 12.0,
             "extracted_audio_path": f"{export_dir}/soundscape_7s-14s.mp3",
             "extracted_spectrogram_path": f"{export_dir}/soundscape_7s-14s.png",
@@ -234,4 +240,4 @@ def test_extraction():
             "start_time": 9.0,
         }
 
-        assert expected_detection == recording.detections[0]
+        assert detection == expected_detection

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -186,14 +186,12 @@ def test_extraction():
             directory=export_dir,
             format="mp3",
             bitrate="128k",
-            min_conf=0.4,
             padding_secs=2,
         )
 
         recording.extract_detections_as_spectrogram(
             directory=export_dir,
             format="png",
-            min_conf=0.4,
             padding_secs=2,
         )
 
@@ -201,16 +199,44 @@ def test_extraction():
         files = os.listdir(export_dir)
         files.sort()
 
+        pprint(files)
+
         expected_files = [
+            "soundscape_31s-38s.mp3",
+            "soundscape_31s-38s.png",
             "soundscape_40s-47s.mp3",
             "soundscape_40s-47s.png",
+            "soundscape_49s-56s.mp3",
+            "soundscape_49s-56s.png",
+            "soundscape_58s-65s.mp3",
+            "soundscape_58s-65s.png",
             "soundscape_64s-71s.mp3",
             "soundscape_64s-71s.png",
+            "soundscape_67s-74s.mp3",
+            "soundscape_67s-74s.png",
             "soundscape_7s-14s.mp3",
             "soundscape_7s-14s.png",
             "soundscape_82s-89s.mp3",
             "soundscape_82s-89s.png",
+            "soundscape_91s-98s.mp3",
+            "soundscape_91s-98s.png",
         ]
         expected_files.sort()
 
         assert files == expected_files
+
+        assert len(recording.detections) == 9
+
+        pprint(recording.detections[0])
+
+        expected_detection = {
+            "common_name": "House Finch",
+            "confidence": 0.5066996216773987,
+            "end_time": 12.0,
+            "extracted_audio_path": f"{export_dir}/soundscape_7s-14s.mp3",
+            "extracted_spectrogram_path": f"{export_dir}/soundscape_7s-14s.png",
+            "scientific_name": "Haemorhous mexicanus",
+            "start_time": 9.0,
+        }
+
+        assert expected_detection == recording.detections[0]

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -227,7 +227,7 @@ def test_extraction():
         detection = recording.detections[0]
 
         # Assert confidence (round for slight float variablity across platforms)
-        assert round(detection["confidence"], 7) == 0.5066996
+        assert round(detection["confidence"], 3) == 0.507
 
         del detection["confidence"]
 

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -199,8 +199,6 @@ def test_extraction():
         files = os.listdir(export_dir)
         files.sort()
 
-        pprint(files)
-
         expected_files = [
             "soundscape_31s-38s.mp3",
             "soundscape_31s-38s.png",
@@ -224,10 +222,7 @@ def test_extraction():
         expected_files.sort()
 
         assert files == expected_files
-
         assert len(recording.detections) == 9
-
-        pprint(recording.detections[0])
 
         expected_detection = {
             "common_name": "House Finch",

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -27,23 +27,29 @@ def test_extraction():
     )
     recording.analyze()
 
-    """
-    TODO: Remove this comment after feature is defined.
+    # TODO: Remove this comment after feature is defined.
 
-    # Local development tests.
+    # # Local development tests.
     
-    export_dir = os.path.join(os.path.dirname(__file__), "extractions")
+    # export_dir = os.path.join(os.path.dirname(__file__), "extractions")
 
-    # Export to mp3 @ 128k for all detections with min_conf of 0.8.
-    recording.extract_detection_as_audio(
-        directory=export_dir, format="mp3", bitrate="128k", min_conf=0.5
-    )
+    # # Export to mp3 @ 128k for all detections with min_conf of 0.8.
+    # recording.extract_detections_as_audio(
+    #     directory=export_dir, format="mp3", bitrate="128k", min_conf=0.5
+    # )
 
-    """
+    # # Extract spectrograms.
+    # recording.extract_detections_as_spectrogram(
+    #     directory=export_dir, min_conf=0.5, format="jpg"
+    # )
+
+    # return
+
+    # Test audio extractions.
 
     # flac test in temporary test directory.
     with tempfile.TemporaryDirectory() as export_dir:
-        recording.extract_detection_as_audio(directory=export_dir)
+        recording.extract_detections_as_audio(directory=export_dir)
 
         # Check file list.
         files = os.listdir(export_dir)
@@ -71,7 +77,7 @@ def test_extraction():
 
     # wav test in temporary test directory.
     with tempfile.TemporaryDirectory() as export_dir:
-        recording.extract_detection_as_audio(directory=export_dir, format="wav")
+        recording.extract_detections_as_audio(directory=export_dir, format="wav")
 
         # Check file list.
         files = os.listdir(export_dir)
@@ -99,7 +105,7 @@ def test_extraction():
     # mp3 test in temporary test directory (with custom min_conf extraction)
     with tempfile.TemporaryDirectory() as export_dir:
 
-        recording.extract_detection_as_audio(
+        recording.extract_detections_as_audio(
             directory=export_dir,
             format="mp3",
             bitrate="128k",
@@ -124,3 +130,87 @@ def test_extraction():
         audio = pydub.AudioSegment.from_mp3(f"{export_dir}/{files[0]}")
         assert audio.frame_rate == 48000
         assert audio.duration_seconds == 7.0
+
+    # Test spectrogram extractions
+
+    # spectrogram test in temporary test directory (with custom min_conf extraction)
+    with tempfile.TemporaryDirectory() as export_dir:
+
+        recording.extract_detections_as_spectrogram(
+            directory=export_dir,
+            format="jpg",
+            min_conf=0.4,
+            padding_secs=2,
+        )
+
+        # Check file list.
+        files = os.listdir(export_dir)
+        files.sort()
+        expected_files = [
+            "soundscape_40s-47s.jpg",
+            "soundscape_64s-71s.jpg",
+            "soundscape_7s-14s.jpg",
+            "soundscape_82s-89s.jpg",
+        ]
+        expected_files.sort()
+
+        assert files == expected_files
+
+    # spectrogram test in temporary test directory (with custom min_conf extraction)
+    with tempfile.TemporaryDirectory() as export_dir:
+
+        recording.extract_detections_as_spectrogram(
+            directory=export_dir,
+            format="png",
+            min_conf=0.4,
+        )
+
+        # Check file list.
+        files = os.listdir(export_dir)
+        files.sort()
+        expected_files = [
+            "soundscape_42s-45s.png",
+            "soundscape_66s-69s.png",
+            "soundscape_84s-87s.png",
+            "soundscape_9s-12s.png",
+        ]
+        expected_files.sort()
+
+        assert files == expected_files
+
+    # Extract audio and spectrogram.
+
+    with tempfile.TemporaryDirectory() as export_dir:
+
+        recording.extract_detections_as_audio(
+            directory=export_dir,
+            format="mp3",
+            bitrate="128k",
+            min_conf=0.4,
+            padding_secs=2,
+        )
+
+        recording.extract_detections_as_spectrogram(
+            directory=export_dir,
+            format="png",
+            min_conf=0.4,
+            padding_secs=2,
+        )
+
+        # Check file list.
+        files = os.listdir(export_dir)
+        files.sort()
+
+        expected_files = [
+            "soundscape_40s-47s.mp3",
+            "soundscape_40s-47s.png",
+            "soundscape_64s-71s.mp3",
+            "soundscape_64s-71s.png",
+            "soundscape_7s-14s.mp3",
+            "soundscape_7s-14s.png",
+            "soundscape_82s-89s.mp3",
+            "soundscape_82s-89s.png",
+        ]
+        expected_files.sort()
+
+        assert files == expected_files


### PR DESCRIPTION
* Adds spectrogram to extraction formats.

```
recording.extract_detections_as_audio(directory=export_dir)
recording.extract_detections_as_spectrogram(directory=export_dir)
```

* Updates documentation.
* Fixes typo with 0.2.0's implementation for `recording.extract_detections_as_audio`.

Full example:
```
# Load and initialize the BirdNET-Analyzer models.
analyzer = Analyzer()

recording = Recording(
    analyzer,
    "2022-08-15-birdnet-21:05:54.wav",
    lat=35.4244,
    lon=-120.7463,
    date=datetime(year=2022, month=5, day=10),  # use date or week_48
    min_conf=0.25,
)
recording.analyze()
export_dir = "extractions"  # Directory should already exist.

# Extract to default audio files (.flac)
recording.extract_detections_as_audio(directory=export_dir)

# Extract to spectrograms
recording.extract_detections_as_spectrogram(directory=export_dir)

pprint(recording.detections)

"""
[{'common_name': 'House Finch',
  'confidence': 0.5066996216773987,
  'end_time': 12.0,
  'extracted_audio_path': 'extractions/2022-08-15-birdnet-21:05:54_9s-12s.flac',
  'extracted_spectrogram_path': 'extractions/2022-08-15-birdnet-21:05:54_9s-12s.jpg',
  'scientific_name': 'Haemorhous mexicanus',
  'start_time': 9.0},
 {'common_name': 'Dark-eyed Junco',
  'confidence': 0.3555494546890259,
  'end_time': 36.0,
  'extracted_audio_path': 'extractions/2022-08-15-birdnet-21:05:54_33s-36s.flac',
  'extracted_spectrogram_path': 'extractions/2022-08-15-birdnet-21:05:54_9s-12s.jpg',
  'scientific_name': 'Junco hyemalis',
  'start_time': 33.0}
 ]
 """

```
![2022-08-15-birdnet-21:05:54_42s-45s](https://user-images.githubusercontent.com/656433/221983542-94cd4e50-689b-4e9c-9b90-35e457d3332e.jpg)
