### PR TITLE
Update helper classes to use BirdNET-Analyzer by default

### DIFF
--- a/examples/batch_directory.py
+++ b/examples/batch_directory.py
@@ -1,5 +1,5 @@
 from birdnetlib.batch import DirectoryAnalyzer
-from birdnetlib.analyzer_lite import LiteAnalyzer
+from birdnetlib.analyzer import Analyzer
 from datetime import datetime
 from pprint import pprint
 
@@ -15,7 +15,7 @@ def on_error(recording, error):
 
 
 print("Starting Analyzer")
-analyzer = LiteAnalyzer()
+analyzer = Analyzer()
 
 
 print("Starting Watcher")

--- a/examples/watch_directory.py
+++ b/examples/watch_directory.py
@@ -1,5 +1,5 @@
 from birdnetlib.watcher import DirectoryWatcher
-from birdnetlib.analyzer_lite import LiteAnalyzer
+from birdnetlib.analyzer import Analyzer
 from datetime import datetime
 from pprint import pprint
 
@@ -15,7 +15,7 @@ def on_error(recording, error):
 
 
 print("Starting Analyzer")
-analyzer = LiteAnalyzer()
+analyzer = Analyzer()
 
 
 print("Starting Watcher")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [
 
 [project]
 name = "birdnetlib"
-version = "0.4.1"
+version = "0.5.0"
 authors = [
   { name="Joe Weiss", email="joe.weiss@gmail.com" },
 ]

--- a/src/birdnetlib/batch.py
+++ b/src/birdnetlib/batch.py
@@ -23,9 +23,9 @@ class DirectoryAnalyzer:
         if len(analyzers) > 0:
             self.analyzers = analyzers
         else:
-            from birdnetlib.analyzer_lite import LiteAnalyzer
+            from birdnetlib.analyzer import Analyzer
 
-            self.analyzers = [LiteAnalyzer()]
+            self.analyzers = [Analyzer()]
 
         # Configuration values for Recording object.
         # Do not norm these values here; let Recording handle them.

--- a/src/birdnetlib/watcher.py
+++ b/src/birdnetlib/watcher.py
@@ -26,9 +26,9 @@ class DirectoryWatcher:
         if len(analyzers) > 0:
             self.analyzers = analyzers
         else:
-            from birdnetlib.analyzer_lite import LiteAnalyzer
+            from birdnetlib.analyzer import Analyzer
 
-            self.analyzers = [LiteAnalyzer()]
+            self.analyzers = [Analyzer()]
 
         # Configuration values for Recording object.
         # Do not norm these values here; let Recording handle them.

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -108,4 +108,4 @@ def test_default_analyzer():
 
     directory = "."
     watcher = DirectoryWatcher(directory)
-    assert type(watcher.analyzers[0]).__name__ == "LiteAnalyzer"
+    assert type(watcher.analyzers[0]).__name__ == "Analyzer"

--- a/tests/test_watcher_both_analyzers.py
+++ b/tests/test_watcher_both_analyzers.py
@@ -69,4 +69,4 @@ def test_default_analyzer():
 
     directory = "."
     watcher = DirectoryWatcher(directory)
-    assert type(watcher.analyzers[0]).__name__ == "LiteAnalyzer"
+    assert type(watcher.analyzers[0]).__name__ == "Analyzer"


### PR DESCRIPTION
Closes #53.

BirdNET-Lite is deprecated. All helper classes will now use BirdNET-Analyzer by default. 

It is still possible to use BirdNET-Lite with the helper classes by including it in the `analyzers` list (see below).

```
def on_analyze_directory_complete(recordings):
    for recording in recordings:
        pprint(recording.detections)

analyzer = LiteAnalyzer()

directory = "."
batch = DirectoryMultiProcessingAnalyzer(
    "/Birds/mp3_dir",
    analyzers=[analyzer],
    patterns=["*.mp3", "*.wav"]
)

batch.on_analyze_directory_complete = on_analyze_directory_complete
batch.process()
```

