### PR TITLE
Add ability to pass custom species list as a kwarg to analyzer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [
 
 [project]
 name = "birdnetlib"
-version = "0.5.1"
+version = "0.6.0"
 authors = [
   { name="Joe Weiss", email="joe.weiss@gmail.com" },
 ]

--- a/src/birdnetlib/analyzer.py
+++ b/src/birdnetlib/analyzer.py
@@ -50,6 +50,7 @@ class Analyzer:
     def __init__(
         self,
         custom_species_list_path=None,
+        custom_species_list=None,
         classifier_model_path=None,
         classifier_labels_path=None,
     ):
@@ -72,12 +73,18 @@ class Analyzer:
 
         self.cached_species_lists = {}
         self.custom_species_list_path = None
+        self.has_custom_species_list = False
 
         self.species_class = SpeciesList()
 
         if custom_species_list_path:
+            self.has_custom_species_list = True
             self.custom_species_list_path = custom_species_list_path
             self.load_custom_list()
+
+        if custom_species_list:
+            self.has_custom_species_list = True
+            self.custom_species_list = custom_species_list
 
     @property
     def detections(self):
@@ -167,9 +174,9 @@ class Analyzer:
     def analyze_recording(self, recording):
         print("analyze_recording", recording.path)
 
-        if self.custom_species_list_path and recording.lon and recording.lat:
+        if self.has_custom_species_list and recording.lon and recording.lat:
             raise ValueError(
-                "Recording lon/lat should not be used in conjunction with a custom species list."
+                "Recording lon/lat should not be used in conjunction with a custom species list or path."
             )
 
         # If recording has lon/lat, load cached list or predict a new species list.

--- a/src/birdnetlib/analyzer_lite.py
+++ b/src/birdnetlib/analyzer_lite.py
@@ -25,7 +25,7 @@ LABEL_PATH = os.path.join(os.path.dirname(__file__), "models/lite/labels.txt")
 
 
 class LiteAnalyzer:
-    def __init__(self, custom_species_list_path=None):
+    def __init__(self, custom_species_list_path=None, custom_species_list=None):
         self.name = "LiteAnalyzer"
         self.model_name = "BirdNET-Lite"
         self.interpreter = None
@@ -41,6 +41,9 @@ class LiteAnalyzer:
         self.load_lite_model()
         if self.custom_species_list_path:
             self.load_custom_list()
+
+        if custom_species_list:
+            self.custom_species_list = custom_species_list
 
     def load_lite_model(self):
         self.interpreter = tflite.Interpreter(model_path=MODEL_PATH)

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -73,7 +73,7 @@ def test_without_species_list():
     assert type(recording.detections[0]["confidence"]) is float
 
 
-def test_with_species_list():
+def test_with_species_list_path():
 
     # Process file with command line utility, then process with python library and ensure equal commandline_results.
 
@@ -118,6 +118,133 @@ def test_with_species_list():
     assert len(commandline_results) > 0
 
     analyzer = Analyzer(custom_species_list_path=custom_list_path)
+    recording = Recording(
+        analyzer,
+        input_path,
+        week_48=week_48,
+        min_conf=min_conf,
+    )
+    recording.analyze()
+
+    assert recording.duration == 120
+
+    pprint(recording.detections)
+
+    assert (
+        commandline_results[0]["common_name"] == recording.detections[0]["common_name"]
+    )
+
+    commandline_birds = [i["common_name"] for i in commandline_results]
+    detected_birds = [i["common_name"] for i in recording.detections]
+    assert commandline_birds == detected_birds
+
+    assert len(recording.detections) == len(commandline_results)
+    assert (
+        len(analyzer.custom_species_list) == 41
+    )  # Check that this matches the number printed by the cli version.
+
+    # Run a recording with lat/lon and throw an error when used with custom species list.
+    with pytest.raises(ValueError):
+        recording = Recording(
+            analyzer,
+            input_path,
+            lon=lon,
+            lat=lat,
+            week_48=week_48,
+            min_conf=min_conf,
+        )
+        recording.analyze()
+
+
+def test_with_species_list():
+
+    # Process file with command line utility, then process with python library and ensure equal commandline_results.
+
+    lon = -120.7463
+    lat = 35.4244
+    week_48 = 18
+    min_conf = 0.25
+    input_path = os.path.join(os.path.dirname(__file__), "test_files/soundscape.wav")
+    custom_list_path = os.path.join(
+        os.path.dirname(__file__), "test_files/species_list.txt"
+    )
+
+    tf = tempfile.NamedTemporaryFile(suffix=".csv")
+    output_path = tf.name
+
+    # Process using python script as is.
+    birdnet_analyzer_path = os.path.join(os.path.dirname(__file__), "BirdNET-Analyzer")
+
+    cmd = f"python analyze.py --i '{input_path}' --o={output_path} --min_conf {min_conf} --slist {custom_list_path} --rtype=csv"
+    os.system(f"cd {birdnet_analyzer_path}; {cmd}")
+
+    with open(tf.name) as f:
+        for line in f:
+            print(line)
+
+    with open(tf.name, newline="") as csvfile:
+        # reader = csv.reader(csvfile, delimiter=";", quotechar="|")
+        reader = csv.DictReader(csvfile)
+        commandline_results = []
+        for row in reader:
+            commandline_results.append(
+                {
+                    "start_time": float(row["Start (s)"]),
+                    "end_time": float(row["End (s)"]),
+                    "common_name": row["Common name"],
+                    "scientific_name": row["Scientific name"],
+                    "confidence": float(row["Confidence"]),
+                }
+            )
+
+    pprint(commandline_results)
+    assert len(commandline_results) > 0
+
+    custom_species_list = [
+        "Accipiter cooperii_Cooper's Hawk",
+        "Anas platyrhynchos_Mallard",
+        "Baeolophus bicolor_Tufted Titmouse",
+        "Branta canadensis_Canada Goose",
+        "Bucephala albeola_Bufflehead",
+        "Bucephala clangula_Common Goldeneye",
+        "Buteo jamaicensis_Red-tailed Hawk",
+        "Cardinalis cardinalis_Northern Cardinal",
+        "Certhia americana_Brown Creeper",
+        "Columba livia_Rock Pigeon",
+        "Corvus brachyrhynchos_American Crow",
+        "Corvus corax_Common Raven",
+        "Cyanocitta cristata_Blue Jay",
+        "Dryobates pubescens_Downy Woodpecker",
+        "Dryobates villosus_Hairy Woodpecker",
+        "Dryocopus pileatus_Pileated Woodpecker",
+        "Haemorhous mexicanus_House Finch",
+        "Haemorhous purpureus_Purple Finch",
+        "Haliaeetus leucocephalus_Bald Eagle",
+        "Junco hyemalis_Dark-eyed Junco",
+        "Larus argentatus_Herring Gull",
+        "Larus delawarensis_Ring-billed Gull",
+        "Larus marinus_Great Black-backed Gull",
+        "Lophodytes cucullatus_Hooded Merganser",
+        "Melanerpes carolinus_Red-bellied Woodpecker",
+        "Meleagris gallopavo_Wild Turkey",
+        "Melospiza melodia_Song Sparrow",
+        "Mergus merganser_Common Merganser",
+        "Passer domesticus_House Sparrow",
+        "Poecile atricapillus_Black-capped Chickadee",
+        "Sialia sialis_Eastern Bluebird",
+        "Sitta canadensis_Red-breasted Nuthatch",
+        "Sitta carolinensis_White-breasted Nuthatch",
+        "Spinus pinus_Pine Siskin",
+        "Spinus tristis_American Goldfinch",
+        "Spizelloides arborea_American Tree Sparrow",
+        "Sturnus vulgaris_European Starling",
+        "Thryothorus ludovicianus_Carolina Wren",
+        "Turdus migratorius_American Robin",
+        "Zenaida macroura_Mourning Dove",
+        "Zonotrichia albicollis_White-throated Sparrow",
+    ]
+
+    analyzer = Analyzer(custom_species_list=custom_species_list)
     recording = Recording(
         analyzer,
         input_path,

--- a/tests/test_analyzer_lite.py
+++ b/tests/test_analyzer_lite.py
@@ -78,7 +78,9 @@ def test_basic():
     assert commandline_results[0]["common_name"] == "House Wren"
     assert pytest.approx(commandline_results[0]["confidence"], 0.01) == 0.27517712
 
-def test_with_custom_list():
+
+
+def test_with_custom_list_path():
 
     lon = -120.7463
     lat = 35.4244
@@ -122,6 +124,79 @@ def test_with_custom_list():
     pprint(commandline_results)
 
     analyzer = LiteAnalyzer(custom_species_list_path=custom_list_path)
+    print(analyzer.custom_species_list)
+    recording = Recording(
+        analyzer,
+        input_path,
+        lat=lat,
+        lon=lon,
+        week_48=week_48,
+        min_conf=min_conf,
+    )
+    recording.analyze()
+
+    pprint(recording.detections)
+
+    assert len(recording.detections) == 1
+    assert len(commandline_results) == 1
+
+    assert recording.detections[0]["common_name"] == "Spotted Towhee"
+    assert pytest.approx(recording.detections[0]["confidence"], 0.01) == 0.55690277
+
+    assert commandline_results[0]["common_name"] == "Spotted Towhee"
+    assert pytest.approx(commandline_results[0]["confidence"], 0.01) == 0.55690277
+
+
+def test_with_custom_list():
+
+    lon = -120.7463
+    lat = 35.4244
+    week_48 = 18
+    min_conf = 0.25
+    input_path = os.path.join(
+        os.path.dirname(__file__), "test_files/XC558716 - Soundscape.mp3"
+    )
+    custom_list_path = os.path.join(
+        os.path.dirname(__file__), "test_files/custom_species_list.txt"
+    )
+
+    tf = tempfile.NamedTemporaryFile()
+    output_path = tf.name
+
+    # Process using python script as is.
+    birdnet_lite_path = os.path.join(os.path.dirname(__file__), "BirdNET-Lite")
+
+    cmd = f"python analyze.py --i '{input_path}' --o={output_path} --lat {lat} --lon {lon} --week {week_48} --min_conf {min_conf} --custom_list {custom_list_path}"
+    os.system(f"cd {birdnet_lite_path}; {cmd}")
+
+    with open(tf.name) as f:
+        for line in f:
+            print(line)
+
+    with open(tf.name, newline="") as csvfile:
+        # reader = csv.reader(csvfile, delimiter=";", quotechar="|")
+        reader = csv.DictReader(csvfile, delimiter=";")
+        commandline_results = []
+        for row in reader:
+            commandline_results.append(
+                {
+                    "start_time": float(row["Start (s)"]),
+                    "end_time": float(row["End (s)"]),
+                    "common_name": row["Common name"],
+                    "scientific_name": row["Scientific name"],
+                    "confidence": float(row["Confidence"]),
+                }
+            )
+
+    pprint(commandline_results)
+
+    custom_species_list = [
+        "Poecile atricapillus_Black-capped Chickadee",
+        "Junco hyemalis_Dark-eyed Junco",
+        "Pipilo maculatus_Spotted Towhee",
+    ]
+
+    analyzer = LiteAnalyzer(custom_species_list=custom_species_list)
     recording = Recording(
         analyzer,
         input_path,


### PR DESCRIPTION
Closes #57.

```
# Custom species list uses the Scientific Name_Common Name format from BirdNET-Analyzer.

 custom_species_list = [
    "Accipiter cooperii_Cooper's Hawk",
    "Anas platyrhynchos_Mallard",
    "Baeolophus bicolor_Tufted Titmouse",
    "Branta canadensis_Canada Goose",
]

analyzer = Analyzer(custom_species_list=custom_species_list)
recording = Recording(
    analyzer,
    input_path,
    min_conf=min_conf,
)
recording.analyze()

```