### PR TITLE
Remove unneeded results prior to species filtering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [
 
 [project]
 name = "birdnetlib"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
   { name="Joe Weiss", email="joe.weiss@gmail.com" },
 ]

--- a/src/birdnetlib/analyzer.py
+++ b/src/birdnetlib/analyzer.py
@@ -199,6 +199,9 @@ class Analyzer:
                 p_labels.items(), key=operator.itemgetter(1), reverse=True
             )
 
+            # Filter by recording.minimum_confidence so not to needlessly store full 8K array for each chunk.
+            p_sorted = [i for i in p_sorted if i[1] >= recording.minimum_confidence]
+
             # Store results
             results[str(start) + "-" + str(end)] = p_sorted
 


### PR DESCRIPTION
Intermediate data of all N results (currently ~3337 birds) is being stored prior to filtering regardless of minimum confidence. This change will filter earlier, which in turn leads to a small, but non-trivial, speed improvement with audio > 30 minutes in length.