### PR TITLE
Download BirdNET-Lite model only as needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,15 @@ print(recording.detections)
 
 To use the legacy BirdNET-Lite model, use the `LiteAnalyzer` class.
 
+Note: The BirdNET-Lite project has been [deprecated](https://github.com/kahst/BirdNET-Lite). The BirdNET-Lite model is no longer included in the PyPi `birdnetlib` package. This model and label file will be downloaded and installed the first time the `LiteAnalyzer` is initialized in your Python environment.
+
 ```python
 from birdnetlib import Recording
 from birdnetlib.analyzer_lite import LiteAnalyzer
 from datetime import datetime
 
 # Load and initialize the BirdNET-Lite models.
+# If this is the first time using LiteAnalyzer, the model will be downloaded into your Python environment.
 analyzer = LiteAnalyzer()
 
 recording = Recording(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "watchdog==2.1.9",
     "pydub==0.25.1",
     "matplotlib>=3.5.3",
+    "requests>=2.28.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.sdist]
 exclude = [
   "/dev",
-  "/tests"
+  "/tests",
+  "/src/birdnetlib/models/lite"
 ]
 
 [project]

--- a/tests/test_ondemand_dependencies.py
+++ b/tests/test_ondemand_dependencies.py
@@ -1,0 +1,34 @@
+from birdnetlib.analyzer_lite import LiteAnalyzer, MODEL_PATH, LABEL_PATH
+import os
+import hashlib
+
+
+def test_downloading_models():
+
+    # Initialize analyzer in repo, will not download.
+    analyzer = LiteAnalyzer()
+    assert analyzer.model_download_was_required == False
+
+    original_hash = hashlib.md5(open(MODEL_PATH, "rb").read()).hexdigest()
+
+    # Temporarily rename the Lite model and labels file.
+    os.rename(MODEL_PATH, f"{MODEL_PATH}_temp")
+    os.rename(LABEL_PATH, f"{LABEL_PATH}_temp")
+
+    # Initialize analyzer without MODEL_PATH or LABEL_PATH existing.
+    analyzer = LiteAnalyzer()
+    assert (
+        analyzer.model_download_was_required
+    )  # Files will have downloaded from Github.
+
+    downloaded_file_hash = hashlib.md5(open(MODEL_PATH, "rb").read()).hexdigest()
+
+    assert (
+        original_hash == downloaded_file_hash
+    )  # Ensure files are a match. BirdNET-Lite is deprecated, so this will likely never change.
+
+    os.unlink(MODEL_PATH)
+    os.unlink(LABEL_PATH)
+
+    os.rename(f"{MODEL_PATH}_temp", MODEL_PATH)
+    os.rename(f"{LABEL_PATH}_temp", LABEL_PATH)


### PR DESCRIPTION
As BirdNET-Lite is officially deprecated (as of April 2022), **and** PyPI's limit of 100MB is blocking `birdnetlib` releases #66, I'm removing BirdNET-Lite's model from of the package.

Starting with release 0.8.0, the `LiteAnalyzer` class will download the model and label file from Github on first use. This should be seamless in most use-cases, as the download will only occur once.

In the unlikely case you need to preload this model without actually using it, I would recommend installing and pinning your requirements to the last version that contained the Lite model `pip install birdnetlib==0.6.1`.

To clarify, this does not affect the current [BirdNET-Analyzer](https://github.com/kahst/BirdNET-Analyzer) project models used in the `Analyzer` class. BirdNET-Analyzer's model is still included in the pip package.

Also, as per the BirdNET project's license, both models remain under the Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License.