### PR TITLE
Refactor multiprocessing to use base class, improve queue performance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = [
 
 [project]
 name = "birdnetlib"
-version = "0.11.0"
+version = "0.12.0"
 authors = [
   { name="Joe Weiss", email="joe.weiss@gmail.com" },
 ]

--- a/src/birdnetlib/batch.py
+++ b/src/birdnetlib/batch.py
@@ -1,4 +1,7 @@
-from birdnetlib import Recording, MultiProcessRecording
+from birdnetlib import (
+    Recording,
+    MultiProcessRecording,
+)
 from pathlib import Path
 from multiprocessing import Pool, Manager
 import multiprocessing
@@ -155,6 +158,7 @@ def process_from_queue(shared_queue, results=[], analyzers=None):
                     "error": True,
                     "error_message": error,
                     "detections": [],
+                    "duration": None,
                 }
             )
     results.append(*recordings)
@@ -288,13 +292,16 @@ class DirectoryMultiProcessingAnalyzer:
 
         for results in directory_recordings:
             # Return as RecordingResults object
-            results = MultiProcessRecording(
-                path=results["path"],
-                config=results["config"],
-                detections=results["detections"],
-                error=results.get("error", False),
-                error_message=results.get("error_message", None),
-            )
+            # pprint(
+            #     {
+            #         "path": results["path"],
+            #         "config": results["config"],
+            #         "detections": results["detections"],
+            #         "error": results.get("error", False),
+            #         "error_message": results.get("error_message", None),
+            #     }
+            # )
+            results = MultiProcessRecording(results=results)
             self.directory_recordings.append(results)
 
         # Look for exceptions.

--- a/src/birdnetlib/batch.py
+++ b/src/birdnetlib/batch.py
@@ -2,7 +2,7 @@ from birdnetlib import Recording, MultiProcessRecording
 from pathlib import Path
 from multiprocessing import Pool, Manager
 import multiprocessing
-
+import queue
 # from pprint import pprint
 
 
@@ -97,10 +97,13 @@ class DirectoryAnalyzer:
 
 def process_from_queue(shared_queue, results=[], analyzers=None):
     print("process_from_queue")
-    if shared_queue.empty():
+
+    try:
+        recording_config, analyzer_args = shared_queue.get(timeout=0)
+    except queue.Empty:
+        # Nothing left in queue, return results.
         return results
-    # print(os.getpid())
-    recording_config, analyzer_args = shared_queue.get()
+
     file_path = recording_config["path"]
 
     # pprint(recording_config)


### PR DESCRIPTION
- Fixes an issue where the multiprocessing queue would sometimes hang during Docker-based usage.
- Adds `extract_` methods to `MultiProcessRecording` objects by subclassing Recording base class for #88 



