### PR TITLE
Reduce resource usage with MultiProcessing

### DIFF
--- a/src/birdnetlib/batch.py
+++ b/src/birdnetlib/batch.py
@@ -98,14 +98,14 @@ class DirectoryAnalyzer:
         self.on_analyze_directory_complete(self.directory_recordings)
 
 
-def process_from_queue(queue_item, results=[], analyzers=None):
+def process_from_queue(queue_item, analyzers=None):
     print("process_from_queue")
 
     try:
         recording_config, analyzer_args = queue_item
     except queue.Empty:
-        # Nothing left in queue, return results.
-        return results
+        # Nothing left in queue
+        return
 
     file_path = recording_config["path"]
 
@@ -161,8 +161,7 @@ def process_from_queue(queue_item, results=[], analyzers=None):
                     "duration": None,
                 }
             )
-    results.append(*recordings)
-    return results
+    return recordings
 
 
 class DirectoryMultiProcessingAnalyzer:

--- a/src/birdnetlib/batch.py
+++ b/src/birdnetlib/batch.py
@@ -162,8 +162,6 @@ def process_from_queue(shared_queue, results=[], analyzers=None):
                 }
             )
     results.append(*recordings)
-    if not shared_queue.empty():
-        process_from_queue(shared_queue, results, analyzers)
     return results
 
 
@@ -275,7 +273,7 @@ class DirectoryMultiProcessingAnalyzer:
 
                 shared_queue.put((recording.__dict__, analyzer_args))
 
-            args = [shared_queue for _ in range(self.processes)]
+            args = [shared_queue for _ in range(shared_queue.qsize())]
 
             with Pool(self.processes) as p:
                 # execute the tasks in parallel


### PR DESCRIPTION
This is a fairly small tweak to reduce the memory usage when using `DirectoryMultiProcessingAnalyzer`.

Currently `process_from_queue` is called recursively by each worker until the `shared_queue` is exhausted. This means that all 'instances' of this function are kept running until the queue is empty. This causes a gradual increase in memory use over time, which can lead to a 'stack overflow' when processing lots of files, or on systems with low RAM.

This PR alters the behaviour to instead call `process_from_queue` 'fresh' each time, preventing this situation from occurring.

(As an aside, these changes would also allow `p.map` to be swapped out for `p.imap` and have `process` yield results as they are generated, rather than building and returning a large results list at the end. This might be useful for checkpointing if the program needs to be restarted, or for passing on results 'as they happen' to other pipelines. But I'll leave that for another PR, if this one is accepted!)