### PR TITLE
Fix issue with setting custom model/labels in Analyzer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = [
 
 [project]
 name = "birdnetlib"
-version = "0.12.0"
+version = "0.12.1"
 authors = [
   { name="Joe Weiss", email="joe.weiss@gmail.com" },
 ]

--- a/src/birdnetlib/analyzer.py
+++ b/src/birdnetlib/analyzer.py
@@ -34,6 +34,10 @@ LABEL_PATH = os.path.join(
 LOCATION_FILTER_THRESHOLD = 0.03
 
 
+class AnalyzerConfigurationError(Exception):
+    pass
+
+
 class Detection:
     def __init__(self, start_time, end_time):
         self.start_time = start_time
@@ -98,8 +102,16 @@ class Analyzer:
         self.classifier_model_path = classifier_model_path
         self.classifier_labels_path = classifier_labels_path
         self.use_custom_classifier = (
-            self.classifier_labels_path and self.classifier_labels_path
+            self.classifier_model_path and self.classifier_labels_path
         )
+        if self.classifier_model_path and not self.use_custom_classifier:
+            raise AnalyzerConfigurationError(
+                "Using a custom-trained classifier requires both classifier_model_path and classifier_labels_path"
+            )
+        if self.classifier_labels_path and not self.use_custom_classifier:
+            raise AnalyzerConfigurationError(
+                "Using a custom-trained classifier requires both classifier_model_path and classifier_labels_path"
+            )
 
         if self.use_custom_classifier:
             self.load_custom_models()
@@ -280,13 +292,11 @@ class Analyzer:
         week_48=None,
         filter_threshold=LOCATION_FILTER_THRESHOLD,
     ):
-
         print("return_predicted_species_list")
 
         return self.species_class.return_list_for_analyzer(
             lat=lat, lon=lon, week_48=week_48, threshold=filter_threshold
         )
-
 
     def set_predicted_species_list_from_position(self, recording):
         print("set_predicted_species_list_from_position")
@@ -325,7 +335,6 @@ class Analyzer:
         end = recording.sample_secs
         results = {}
         for c in recording.chunks:
-
             if self.use_custom_classifier:
                 pred = self.predict_with_custom_classifier(c)[0]
             else:
@@ -375,7 +384,6 @@ class Analyzer:
             self.output_layer_index = self.output_details[0]["index"]
 
         print("Model loaded.")
-
 
     def load_labels(self):
         labels_file_path = self.label_path

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,5 +1,5 @@
 from birdnetlib import Recording
-from birdnetlib.analyzer import Analyzer, MODEL_PATH, LABEL_PATH
+from birdnetlib.analyzer import Analyzer, AnalyzerConfigurationError
 
 from pprint import pprint
 import pytest
@@ -10,7 +10,6 @@ from unittest.mock import patch
 
 
 def test_without_species_list():
-
     # Process file with command line utility, then process with python library and ensure equal commandline_results.
 
     lon = -120.7463
@@ -74,7 +73,6 @@ def test_without_species_list():
 
 
 def test_with_species_list_path():
-
     # Process file with command line utility, then process with python library and ensure equal commandline_results.
 
     lon = -120.7463
@@ -157,7 +155,6 @@ def test_with_species_list_path():
 
 
 def test_with_species_list():
-
     # Process file with command line utility, then process with python library and ensure equal commandline_results.
 
     lon = -120.7463
@@ -288,8 +285,19 @@ def test_with_species_list():
         recording.analyze()
 
 
-def test_species_list_calls():
+def test_custom_trained_analyzer():
+    expected_message = "Using a custom-trained classifier requires both classifier_model_path and classifier_labels_path"
 
+    with pytest.raises(AnalyzerConfigurationError) as exc_info:
+        analyzer = Analyzer(classifier_model_path="/some/path/")
+    assert str(exc_info.value) == expected_message
+
+    with pytest.raises(AnalyzerConfigurationError) as exc_info:
+        analyzer = Analyzer(classifier_labels_path="/some/path/")
+    assert str(exc_info.value) == expected_message
+
+
+def test_species_list_calls():
     lon = -120.7463
     lat = 35.4244
     week_48 = 18


### PR DESCRIPTION
Fixes #91 and adds test case for configuration.

`AnalyzerConfigurationError` now raised if  `classifier_model_path` and `classifier_labels_path` are not used together.

```python
from birdnetlib.analyzer import Analyzer, AnalyzerConfigurationError
analyzer = Analyzer(classifier_model_path="/some/path/")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/birdnetlib/src/birdnetlib/analyzer.py", line 108, in __init__
    raise AnalyzerConfigurationError(
birdnetlib.analyzer.AnalyzerConfigurationError: Using a custom-trained classifier requires both classifier_model_path and classifier_labels_path



```

