### PR TITLE
Add option to annotate detections rather than filtering them out when providing location/date

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,49 @@ recording.analyze()
 print(recording.detections)
 ```
 
+All recording classes can accept an optional lat, lon and date arguments, which will limit the detections to species to those predicted to be included.
+
+```python
+from birdnetlib import Recording
+from birdnetlib.analyzer import Analyzer
+
+analyzer = Analyzer()
+
+recording = Recording(
+    analyzer,
+    "sample.mp3",
+    min_conf=0.25,
+    lat=35.6,
+    lon=-77.3,
+    date=datetime(year=2023, month=6, day=27),
+)
+recording.analyze()
+print(recording.detections)
+```
+
+It is also possible to return all detections, but annotate the detection if the species is on the predicted list for that location and date.
+
+```python
+from birdnetlib import Recording
+from birdnetlib.analyzer import Analyzer
+
+analyzer = Analyzer()
+
+recording = Recording(
+    analyzer,
+    "sample.mp3",
+    min_conf=0.25,
+    lat=35.6,
+    lon=-77.3,
+    date=datetime(year=2023, month=6, day=27),
+    is_predicted_for_location_and_date=True,
+)
+recording.analyze()
+print(recording.detections)
+```
+
+
+
 ### RecordingFileObject
 
 Use the `RecordingFileObject` class to analyze an in-memory file object.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = [
 
 [project]
 name = "birdnetlib"
-version = "0.14.0"
+version = "0.15.0"
 authors = [
   { name="Joe Weiss", email="joe.weiss@gmail.com" },
 ]

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -58,18 +58,24 @@ def test_without_species_list():
         lon=lon,
         week_48=week_48,
         min_conf=min_conf,
+        return_all_detections=True,
     )
     recording.analyze()
     pprint(recording.detections)
 
     # Check that birdnetlib results match command line results.
-    assert len(recording.detections) == len(commandline_results)
+    assert len(recording.detections) == 25
+    # Check those that are predicted for location/date.
+    detections_species_predicted = [
+        i for i in recording.detections if i["is_predicted_for_location_and_date"]
+    ]
+    assert len(detections_species_predicted) == len(commandline_results)
     assert (
         len(analyzer.custom_species_list) == 195
     )  # Check that this matches the number printed by the cli version.
 
     # Check that detection confidence is float.
-    assert type(recording.detections[0]["confidence"]) is float
+    assert isinstance(recording.detections[0]["confidence"], float)
 
 
 def test_with_species_list_path():


### PR DESCRIPTION
Implements #106. Entirely optional addition.

```
from birdnetlib import Recording
from birdnetlib.analyzer import Analyzer

analyzer = Analyzer()

recording = Recording(
    analyzer,
    "sample.mp3",
    min_conf=0.25,
    lat=35.6,
    lon=-77.3,
    date=datetime(year=2023, month=6, day=27),
    is_predicted_for_location_and_date=True,
)
recording.analyze()
print(recording.detections)

```

Returns the following.

```
{'common_name': 'Engine',
  'confidence': 0.516838550567627,
  'end_time': 114.0,
  'is_predicted_for_location_and_date': False,
  'label': 'Engine_Engine',
  'scientific_name': 'Engine',
  'start_time': 111.0},
 {'common_name': 'American Goldfinch',
  'confidence': 0.39239490032196045,
  'end_time': 120.0,
  'is_predicted_for_location_and_date': True,
  'label': 'Spinus tristis_American Goldfinch',
  'scientific_name': 'Spinus tristis',
  'start_time': 117.0}]


```



