### PR TITLE
Add verbose option to turn off logs for scripting

### DIFF
--- a/src/birdnetlib/analyzer.py
+++ b/src/birdnetlib/analyzer.py
@@ -68,6 +68,7 @@ class Analyzer:
         classifier_model_path=None,
         classifier_labels_path=None,
         version=None,
+        verbose=True,
     ):
         self.name = "Analyzer"
         self.model_name = "BirdNET-Analyzer"
@@ -100,6 +101,8 @@ class Analyzer:
         if self.version != MODEL_VERSION:
             # Download version dynamically if there's a match.
             self.check_for_model_files()
+
+        self.verbose = verbose
 
         self.classifier_model_path = classifier_model_path
         self.classifier_labels_path = classifier_labels_path
@@ -294,14 +297,16 @@ class Analyzer:
         week_48=None,
         filter_threshold=LOCATION_FILTER_THRESHOLD,
     ):
-        print("return_predicted_species_list")
+        if self.verbose:
+            print("return_predicted_species_list")
 
         return self.species_class.return_list_for_analyzer(
             lat=lat, lon=lon, week_48=week_48, threshold=filter_threshold
         )
 
     def set_predicted_species_list_from_position(self, recording):
-        print("set_predicted_species_list_from_position")
+        if self.verbose:
+            print("set_predicted_species_list_from_position")
 
         # Check to see if this species list has been previously cached.
         list_key = f"list-{recording.lon}-{recording.lat}-{recording.week_48}"
@@ -321,7 +326,8 @@ class Analyzer:
         self.cached_species_lists[list_key] = species_list
 
     def analyze_recording(self, recording):
-        print("analyze_recording", recording.filename)
+        if self.verbose:
+            print("analyze_recording", recording.filename)
 
         if self.has_custom_species_list and recording.lon and recording.lat:
             raise ValueError(
@@ -330,7 +336,8 @@ class Analyzer:
 
         # If recording has lon/lat, load cached list or predict a new species list.
         if recording.lon and recording.lat and self.classifier_model_path == None:
-            print("recording has lon/lat")
+            if self.verbose:
+                print("recording has lon/lat")
             self.set_predicted_species_list_from_position(recording)
 
         start = 0
@@ -364,7 +371,8 @@ class Analyzer:
         recording.detection_list = self.detections
 
     def extract_embeddings_for_recording(self, recording):
-        print("extract_embeddings_for_recording", recording.filename)
+        if self.verbose:
+            print("extract_embeddings_for_recording", recording.filename)
         start = 0
         end = recording.sample_secs
         results = []

--- a/src/birdnetlib/main.py
+++ b/src/birdnetlib/main.py
@@ -30,6 +30,7 @@ class RecordingBase:
         min_conf=0.1,
         overlap=0.0,
         return_all_detections=False,
+        verbose=True,
     ):
         self.analyzer = analyzer
         self.detections_dict = {}  # Old format
@@ -169,8 +170,8 @@ class RecordingBase:
             chunks.append(split)
 
         self.chunks = chunks
-
-        print("read_audio_data: complete, read ", str(len(self.chunks)), "chunks.")
+        if self.verbose:
+            print("read_audio_data: complete, read ", str(len(self.chunks)), "chunks.")
 
     def get_extract_array(self, start_sec, end_sec):
         # Returns ndarray trimmed for start_sec:end_sec
@@ -278,6 +279,7 @@ class Recording(RecordingBase):
         min_conf=0.1,
         overlap=0.0,
         return_all_detections=False,
+        **kwargs,
     ):
         self.path = path
         p = Path(self.path)
@@ -292,6 +294,7 @@ class Recording(RecordingBase):
             min_conf,
             overlap,
             return_all_detections,
+            **kwargs,
         )
 
     @property
@@ -333,6 +336,7 @@ class RecordingBuffer(RecordingBase):
         min_conf=0.1,
         overlap=0.0,
         return_all_detections=False,
+        **kwargs,
     ):
         self.buffer = buffer
         self.rate = rate
@@ -346,6 +350,7 @@ class RecordingBuffer(RecordingBase):
             min_conf,
             overlap,
             return_all_detections,
+            **kwargs,
         )
 
     @property
@@ -371,6 +376,7 @@ class RecordingFileObject(RecordingBase):
         min_conf=0.1,
         overlap=0.0,
         return_all_detections=False,
+        **kwargs,
     ):
         self.file_obj = file_obj
         super().__init__(
@@ -383,6 +389,7 @@ class RecordingFileObject(RecordingBase):
             min_conf,
             overlap,
             return_all_detections,
+            **kwargs,
         )
 
     @property
@@ -423,6 +430,7 @@ class LargeRecording(Recording):
         min_conf=0.1,
         overlap=0,
         return_all_detections=False,
+        **kwargs,
     ):
         super().__init__(
             analyzer,
@@ -435,6 +443,7 @@ class LargeRecording(Recording):
             min_conf,
             overlap,
             return_all_detections,
+            **kwargs,
         )
 
     def analyze(self):

--- a/src/birdnetlib/main.py
+++ b/src/birdnetlib/main.py
@@ -51,6 +51,7 @@ class RecordingBase:
         self.extracted_audio_paths = {}
         self.extracted_spectrogram_paths = {}
         self.return_all_detections = return_all_detections
+        self.verbose = verbose
 
     def analyze(self):
         # Check that analyzer is not LargeRecordingAnalyzer


### PR DESCRIPTION
Thanks for the excellent library to interface with BirdNET. I found last year that some of the logging was too verbose, so I added an option to configure it. In particular, it can be painful to run the script when there are thousands of files that are being processed.

Let me know if there are any changes that you'd like to see here. 