### PR TITLE
Pass PatternMatchingEventHandler arguments by keyword, allowing watchdog 2.1.9-6.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
 ]
 dependencies = [
-    "watchdog==2.1.9",
+    "watchdog>=2.1.9,<7",
     "pydub==0.25.1",
     "matplotlib>=3.5.3",
     "requests>=2.28.1",

--- a/src/birdnetlib/watcher.py
+++ b/src/birdnetlib/watcher.py
@@ -89,7 +89,10 @@ class DirectoryWatcher:
         ignore_directories = False
         case_sensitive = True
         my_event_handler = PatternMatchingEventHandler(
-            patterns, ignore_patterns, ignore_directories, case_sensitive
+            patterns=patterns,
+            ignore_patterns=ignore_patterns,
+            ignore_directories=ignore_directories,
+            case_sensitive=case_sensitive,
         )
         my_event_handler.on_closed = self._on_closed
         go_recursively = True

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -115,3 +115,54 @@ def test_default_analyzer():
     directory = "."
     watcher = DirectoryWatcher(directory)
     assert type(watcher.analyzers[0]).__name__ == "Analyzer"
+
+
+class StopWatching(Exception):
+    """Sentinel used to break out of watch()'s otherwise endless loop."""
+
+
+def run_watch_with_mocked_watchdog(watcher):
+    # watch() never returns on its own, so stop it at the observer's start()
+    # call, after every watchdog object has been constructed and wired up.
+    with patch("birdnetlib.watcher.PatternMatchingEventHandler") as handler_class:
+        with patch("birdnetlib.watcher.Observer") as observer_class:
+            observer_class.return_value.start.side_effect = StopWatching
+            with pytest.raises(StopWatching):
+                watcher.watch()
+    return handler_class, observer_class
+
+
+def test_watch_builds_event_handler_with_keyword_arguments():
+
+    # watchdog 5.0.0 made PatternMatchingEventHandler's arguments keyword-only,
+    # so passing them positionally is what pins birdnetlib to watchdog < 5.
+
+    watcher = DirectoryWatcher(".", analyzers=[Mock()])
+
+    handler_class, _ = run_watch_with_mocked_watchdog(watcher)
+
+    assert handler_class.call_count == 1
+    args, kwargs = handler_class.call_args
+    assert args == ()
+    assert kwargs == {
+        "patterns": ["*.mp3", "*.wav"],
+        "ignore_patterns": None,
+        "ignore_directories": False,
+        "case_sensitive": True,
+    }
+
+
+def test_watch_schedules_event_handler_with_recursive_by_keyword():
+
+    # The other half of watch()'s watchdog call surface.
+
+    directory = os.path.join(os.path.dirname(__file__), "test_files")
+    watcher = DirectoryWatcher(directory, analyzers=[Mock()])
+
+    handler_class, observer_class = run_watch_with_mocked_watchdog(watcher)
+
+    observer = observer_class.return_value
+    assert observer.schedule.call_count == 1
+    args, kwargs = observer.schedule.call_args
+    assert args == (handler_class.return_value, directory)
+    assert kwargs == {"recursive": True}


### PR DESCRIPTION
## Summary

`DirectoryWatcher.watch()` builds watchdog's `PatternMatchingEventHandler` with positional arguments, which watchdog 5.0.0 made keyword-only. That call is what holds the requirement at exactly `watchdog==2.1.9`; passing the arguments by keyword lets it widen to `>=2.1.9,<7`.

To be clear about the severity: with the exact pin in place an ordinary install never reaches that code path, so this is not a crash anyone is hitting today. It is the thing that blocks relaxing the pin.

## Related Issues and Pull Requests

Relates to LetsGetToWorkBro/dreamlayer#612 — a downstream project that currently cannot install `birdnetlib` alongside anything requiring `watchdog>=6`, and has had to declare the two feature sets mutually exclusive.

## Changes

- `src/birdnetlib/watcher.py` — `PatternMatchingEventHandler(...)` now receives `patterns`, `ignore_patterns`, `ignore_directories` and `case_sensitive` by keyword instead of positionally. `case_sensitive` stays explicit, since birdnetlib passes `True` and watchdog defaults to `False`.
- `pyproject.toml` — `watchdog==2.1.9` → `watchdog>=2.1.9,<7`.
- `tests/test_watcher.py` — two tests covering both halves of `watch()`'s watchdog call surface: the handler construction, and that `Observer.schedule` receives `recursive` by keyword. `watch()` never returns on its own, so the patched observer's `start()` raises a sentinel the test catches; no production code was restructured to make this testable.

`Observer.schedule` needed no change — `recursive` also became keyword-only in 5.0.0, but it was already being passed by keyword. The handler construction is the only affected call in the package.

## Testing

- Full CI suite on Python 3.9, 3.10 and 3.11: **49 passed, 7 skipped**, with `pip install .` resolving **watchdog 6.0.0** under the widened requirement.
- Compared against a run of unmodified `main` for the same workflow: baseline collects 62 tests and resolves watchdog 2.1.9; this branch collects 64 and resolves 6.0.0. The +2 confirms the new tests execute, and the version change confirms the requirement edit is not inert.
- The handler-construction test fails by assertion (on the recorded positional arguments) when the `watcher.py` change is reverted, and passes with it.
- Exercised `watch()` end to end against real watchdog 6.0.0 and real inotify — `.mp3` and `.wav` close events reach `_on_closed`, `.txt` is correctly ignored — and confirmed identical behaviour on 2.1.9.
- Confirmed the keyword form is accepted, under identical parameter names, on 2.1.9, 3.0.0, 4.0.2, 5.0.0 and 6.0.0, so no version-conditional code or lower-bound bump is needed. The keyword-only change was traced to 5.0.0 (#1057) from the package sources.
- The 17 failures seen when running the suite locally are environmental — they shell out to the BirdNET-Analyzer reference CLI and need the submodules plus a `python` on PATH. They reproduce identically on unmodified `main`.

## Follow-ups / Known Limitations

- **The `<7` ceiling is a deliberate choice, not a necessity, and I'd rather you picked.** watchdog 7 (unreleased; #1101) switches pattern matching from `path.match()` to `path.full_match()`, under which the current `["*.mp3", "*.wav"]` stop matching — measured against watchdog `master`, not inferred. An alternative that needs no ceiling is adding `"**/*.mp3", "**/*.wav"` *alongside* the existing patterns, which matches on every version from 2.1.9 through 7.0.0-dev. I left it out to keep this to one concern; happy to add it and drop the bound if you prefer. One caveat if you take it: replacing `*.mp3` *with* `**/*.mp3` — what the 7.0.0 changelog advises — regresses on watchdog ≤6 for a bare relative watch path. Only the union of both forms is safe across the whole range.
- `watch()` has no coverage for `my_event_handler.on_closed = self._on_closed`: deleting that line yields a watcher that analyses nothing and still passes the whole module. Pre-existing and outside this change; a one-line assertion would close it if you want it.

## Dependencies

`watchdog` widened from `==2.1.9` to `>=2.1.9,<7`. No new dependency, and no effect on `requires-python` — watchdog 5.x and 6.x both declare `>=3.9`, matching birdnetlib's own floor.

## Footer

Generated by Claude Opus 5 (brief, implementation, review, verification)
